### PR TITLE
Force JSON content type

### DIFF
--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -31,7 +31,11 @@ module Cangaroo
       end
 
       def headers
-        { 'X_HUB_TOKEN' => connection.token }
+        {
+          'X_HUB_TOKEN' => connection.token,
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+        }
       end
 
       def body(payload, request_id, parameters)


### PR DESCRIPTION
When pushing to a rails-based endpoint, if `Content-type` is not explicitly set to JSON `params` won't be a parsed JSON hash. This requires additional code to be written on the endpoint side to handle parsing JSON.

I haven't tested sinatra based endpoints, but I believe any endpoints based on `endpoint_base` do something along the lines of `JSON.parse(request.body)`, so they would not be effected by this change. 