### PR TITLE
Set default parameters in `after_initialize` call

### DIFF
--- a/app/models/cangaroo/connection.rb
+++ b/app/models/cangaroo/connection.rb
@@ -5,8 +5,16 @@ module Cangaroo
     validates :name, :url, :key, :token, presence: true
     validates :name, :url, :key, :token, uniqueness: true
 
+    after_initialize :set_default_parameters
+
     def self.authenticate(key, token)
       where(key: key, token: token).first
     end
+
+    private
+
+      def set_default_parameters
+        self.parameters ||= {}
+      end
   end
 end

--- a/db/migrate/20151030140821_add_parameters_to_cangaroo_connection.rb
+++ b/db/migrate/20151030140821_add_parameters_to_cangaroo_connection.rb
@@ -1,5 +1,5 @@
 class AddParametersToCangarooConnection < ActiveRecord::Migration
   def change
-    add_column :cangaroo_connections, :parameters, :text, default: {}
+    add_column :cangaroo_connections, :parameters, :text
   end
 end


### PR DESCRIPTION
`default: {}` caused a fatal error for me on rails5 + postgres (not sure which was causing the error). Given that the implementation of `serialize` could change, I think it's best to set defaults in `after_initialize` and avoid attempting to get the default set correctly on the database side as [outlined in this SO post](http://stackoverflow.com/questions/4943435/default-for-serialized-column-in-activerecord-migration).