### PR TITLE
Basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ Each connection must have these fields:
     (used to check the request's 'X-Hub-Store' header)
   * token - (required, String) It's used for authentication
     (used to check the request's 'X-Hub-Access-Token' header)
+  * basic_auth - (optional, Boolean) Defaults to false. If you would like to
+    use HTTP basic auth in your integration instead of Wombat's key + token.
+    Basic auth is handled [Stripe-style](https://www.quora.com/Why-does-Stripe-use-HTTP-Basic-Auth-with-a-token-instead-of-a-header),
+    without a username using `key` as your password. 
   * parameters - (optional, Hash) Used as parameters when Cangaroo makes a
     request to this connection
 

--- a/app/controllers/cangaroo/endpoint_controller.rb
+++ b/app/controllers/cangaroo/endpoint_controller.rb
@@ -39,7 +39,12 @@ module Cangaroo
     end
 
     def key
-      request.headers['X-Hub-Store']
+      if Rails.configuration.cangaroo.basic_auth
+        user, pass = ActionController::HttpAuthentication::Basic::user_name_and_password(request)
+        pass
+      else
+        request.headers['X-Hub-Store']
+      end
     end
 
     def token

--- a/lib/cangaroo/engine.rb
+++ b/lib/cangaroo/engine.rb
@@ -12,6 +12,7 @@ module Cangaroo
     config.before_configuration do
       Rails.configuration.cangaroo = ActiveSupport::OrderedOptions.new
       Rails.configuration.cangaroo.jobs = []
+      Rails.configuration.cangaroo.basic_auth = false
     end
   end
 end

--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -14,7 +14,23 @@ module Cangaroo
 
       def post(payload, request_id, parameters)
         request_body = body(payload, request_id, parameters).to_json
-        req = self.class.post(url, headers: headers, body: request_body)
+
+        request_options = {
+          headers: headers,
+          body: request_body
+        }
+
+        if Rails.configuration.cangaroo.basic_auth
+          request_options.merge!(
+            basic_auth: {
+              username: connection.key,
+              password: connection.token
+            }
+          )
+        end
+
+        req = self.class.post(url, request_options)
+
         if req.response.code == '200'
           req.parsed_response
         elsif req.response.code == '203'
@@ -34,7 +50,7 @@ module Cangaroo
 
       def headers
         {
-          'X_HUB_TOKEN' => connection.token,
+          'X_HUB_TOKEN' => connection.token || '',
           'Content-Type' => 'application/json',
           'Accept' => 'application/json'
         }

--- a/spec/lib/cangaroo/webhook/client_spec.rb
+++ b/spec/lib/cangaroo/webhook/client_spec.rb
@@ -37,6 +37,21 @@ module Cangaroo
               }.to_json)
         end
 
+        context 'when basic auth is enabled' do
+          before { Rails.configuration.cangaroo.basic_auth = true }
+
+          it 'sends key and token as basic auth username and password' do
+            expect(client.class).to receive(:post)
+              .with(anything, hash_including(basic_auth: {
+                username: connection.key,
+                password: connection.token }
+              ))
+              .and_return(double(response: double(code: '200'), parsed_response: response))
+
+            client.post(payload, request_id, parameters)
+          end
+        end
+
         context 'when response code is 200 (success)' do
           it 'returns the parsed response' do
             expect(client.post(payload, request_id, parameters))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,12 @@ RSpec.configure do |config|
     end
   end
 
+  # reset config before each spec
+  config.before(:each) do
+    Rails.configuration.cangaroo.basic_auth = false
+    Rails.configuration.cangaroo.jobs = []
+  end
+
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Given that cangaroo/wombat common use-case is most likely going to be single-tenant environments, I think there is a significant benefit to moving to HTTP basic auth for endpoing<>cangaroo authentication. 

* Makes it easier to test payloads against an endpoint via the CLI. Lots of tools support HTTP basic auth, which makes it really easy to pass authentication to an endpoint
* 1/2 the number of keys to manage
* Backwards compatible

Let me know what you think! I can write up some specs if this is something that makes sense to merge into master.