### PR TITLE
Making job methods protected for easy use in subclasses

### DIFF
--- a/app/jobs/cangaroo/job.rb
+++ b/app/jobs/cangaroo/job.rb
@@ -30,7 +30,7 @@ module Cangaroo
       { type.singularize => payload }
     end
 
-    private
+    protected
 
     def source_connection
       arguments.first.fetch(:connection)


### PR DESCRIPTION
`destination_connection` is especially useful in `perform?` subclasses.