### PR TITLE
Gracefully handle non-json endpoint response

### DIFF
--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -20,7 +20,7 @@ module Cangaroo
         elsif req.response.code == '203'
           ''
         else
-          fail Cangaroo::Webhook::Error, req.parsed_response['summary']
+          fail Cangaroo::Webhook::Error, (req.parsed_response['summary'] rescue req.response)
         end
       end
 

--- a/spec/lib/cangaroo/webhook/client_spec.rb
+++ b/spec/lib/cangaroo/webhook/client_spec.rb
@@ -71,6 +71,21 @@ module Cangaroo
               .to raise_error(Cangaroo::Webhook::Error)
           end
         end
+
+        context 'when response code is not 200 and response is not json' do
+          let(:failure_response) { 'i am not json' }
+
+          before do
+            stub_request(:post, /^#{url}.*/).to_return(
+              body: failure_response,
+              status: 500)
+          end
+
+          it 'raises Cangaroo::Webhook::Error' do
+            expect { client.post(payload, request_id, parameters) }
+              .to raise_error(Cangaroo::Webhook::Error)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This can easily happen in the case of a 500 or other unexpected error