### PR TITLE
Handle empty content

### DIFF
--- a/app/jobs/cangaroo/job.rb
+++ b/app/jobs/cangaroo/job.rb
@@ -37,6 +37,9 @@ module Cangaroo
     end
 
     def restart_flow(response)
+      # if no json was returned, the response should be discarded
+      return if response.blank?
+
       PerformFlow.call(
         source_connection: destination_connection,
         json_body: response.to_json,

--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -17,6 +17,8 @@ module Cangaroo
         req = self.class.post(url, headers: headers, body: request_body)
         if req.response.code == '200'
           req.parsed_response
+        elsif req.response.code == '203'
+          ''
         else
           fail Cangaroo::Webhook::Error, req.parsed_response['summary']
         end

--- a/spec/jobs/cangaroo/job_spec.rb
+++ b/spec/jobs/cangaroo/job_spec.rb
@@ -49,9 +49,20 @@ module Cangaroo
       it 'restart the flow' do
         job.perform
         expect(Cangaroo::PerformFlow).to have_received(:call)
+          .once
           .with(source_connection: destination_connection,
                 json_body: connection_response.to_json,
                 jobs: Rails.configuration.cangaroo.jobs)
+      end
+
+      context 'endpoint provides a empty response' do
+        it 'should not restart the flow' do
+          client.stub(:post).and_return('')
+
+          job.perform
+
+          expect(Cangaroo::PerformFlow).to_not have_received(:call)
+        end
       end
     end
 

--- a/spec/lib/cangaroo/webhook/client_spec.rb
+++ b/spec/lib/cangaroo/webhook/client_spec.rb
@@ -44,6 +44,14 @@ module Cangaroo
           end
         end
 
+        context 'when response code is 203 (no content)' do
+          it 'returns an empty string' do
+            stub_request(:post, /^#{url}.*/).to_return(status: 203, body: '')
+
+            expect(client.post(payload, request_id, parameters)).to eq('')
+          end
+        end
+
         context 'when response code is not 200 (success)' do
           let(:failure_response) do
             {


### PR DESCRIPTION
Reprocessing a response is an awesome feature, but I think we should also support skipping reprocessing if 203 / no content is the HTTP response.