### PR TITLE
delete parameters from context.json_data before validating schema

### DIFF
--- a/app/interactors/cangaroo/count_json_object.rb
+++ b/app/interactors/cangaroo/count_json_object.rb
@@ -14,7 +14,7 @@ module Cangaroo
     private
 
     def prepare_context
-      context.data = JSON.parse(context.json_body)
+      context.data = context.json_body
     end
   end
 end

--- a/app/interactors/cangaroo/perform_jobs.rb
+++ b/app/interactors/cangaroo/perform_jobs.rb
@@ -11,7 +11,7 @@ module Cangaroo
     private
 
     def data
-      @data ||= JSON.parse(context.json_body)
+      @data ||= context.json_body
     end
 
     def enqueue_jobs(type, payload)

--- a/app/interactors/cangaroo/validate_json_schema.rb
+++ b/app/interactors/cangaroo/validate_json_schema.rb
@@ -27,7 +27,7 @@ module Cangaroo
     before :prepare_context
 
     def call
-      validation_response = JSON::Validator.fully_validate(SCHEMA, context.json_body)
+      validation_response = JSON::Validator.fully_validate(SCHEMA, context.json_body.to_json)
 
       if validation_response.empty?
         return true
@@ -41,6 +41,7 @@ module Cangaroo
     def prepare_context
       context.request_id = context.json_body.delete('request_id')
       context.summary = context.json_body.delete('summary')
+      context.parameters = context.json_body.delete('parameters')
     end
   end
 end

--- a/app/jobs/cangaroo/job.rb
+++ b/app/jobs/cangaroo/job.rb
@@ -33,7 +33,7 @@ module Cangaroo
 
       PerformFlow.call(
         source_connection: destination_connection,
-        json_body: response.to_json,
+        json_body: response,
         jobs: Rails.configuration.cangaroo.jobs
       )
     end


### PR DESCRIPTION
`context.json_body` can also include `parameters` in addition to `request_id` and `summary`, which is as per the guidelines given by wombat.

Therefore removing it from `context.json_body` before validating objects schema.

fixes #22 