### PR TITLE
Fix validate json schema

### DIFF
--- a/app/interactors/cangaroo/validate_json_schema.rb
+++ b/app/interactors/cangaroo/validate_json_schema.rb
@@ -40,6 +40,7 @@ module Cangaroo
     def prepare_context
       context.request_id = context.json_body.delete('request_id')
       context.summary = context.json_body.delete('summary')
+      context.parameters = context.json_body.delete('parameters')
     end
   end
 end

--- a/spec/fixtures/json_payload_connection_response.json
+++ b/spec/fixtures/json_payload_connection_response.json
@@ -1,6 +1,7 @@
 {
   "request_id": "c143e548-afed-44ab-9997-43614d6c762b",
   "summary": "Product added with Shopify ID of 5775282183 was added.",
+  "parameters": {},
   "products": [
     {
       "id": "SKUPRODUCT",


### PR DESCRIPTION
Related to this issue https://github.com/nebulab/cangaroo/issues/22.
Update the json validator to accept an extra parameter (parameters)
that can be present when data come from a remote connection.