### PR TITLE
Fix last_poll fetch in PollJob

### DIFF
--- a/app/jobs/cangaroo/poll_job.rb
+++ b/app/jobs/cangaroo/poll_job.rb
@@ -13,7 +13,6 @@ module Cangaroo
     def perform(*)
       log.set_context(self)
 
-      last_poll = Time.at(arguments.first.fetch(:last_poll)).to_datetime
       current_time = DateTime.now
 
       if !perform?(current_time)
@@ -21,7 +20,7 @@ module Cangaroo
         return
       end
 
-      log.info 'initiating poll', last_poll: last_poll.to_i
+      log.info 'initiating poll', last_poll: last_poll_timestamp.to_i
 
       response = Cangaroo::Webhook::Client.new(destination_connection, path)
         .post({ last_poll: last_poll_timestamp.to_i }, @job_id, parameters)


### PR DESCRIPTION
As i see, `last_poll` is only used for displaying a log, we could instead use `last_poll_timestamp`.

It should fix #28

What do you think @iloveitaly and @AlessioRocco ?