### PR TITLE
Loosening schema definition

### DIFF
--- a/app/interactors/cangaroo/validate_json_schema.rb
+++ b/app/interactors/cangaroo/validate_json_schema.rb
@@ -8,16 +8,11 @@ module Cangaroo
       'minProperties': 1,
       'additionalProperties': false,
       'patternProperties': {
-        '^[a-z]*$': {
+        '^[a-z-_]*$': {
           'type': 'array',
           'items': {
             'type': 'object',
-            'required': ['id'],
-            'properties': {
-              'id': {
-                'type': 'string'
-              }
-            }
+            'required': ['id']
           }
         }
       }


### PR DESCRIPTION
* Allows empty ID fields and integer ID fields
* Allows object names with hyphens and underscores