### PR TITLE
Change logger class

### DIFF
--- a/app/interactors/cangaroo/count_json_object.rb
+++ b/app/interactors/cangaroo/count_json_object.rb
@@ -1,6 +1,5 @@
 module Cangaroo
   class CountJsonObject
-    include Cangaroo::Log
     include Interactor
 
     before :prepare_context
@@ -10,7 +9,7 @@ module Cangaroo
         o[k] = v.size
       end
 
-      log.info 'total consumed payloads', count: context.object_count
+      Cangaroo.logger.info 'total consumed payloads', count: context.object_count
     end
 
     private

--- a/lib/cangaroo.rb
+++ b/lib/cangaroo.rb
@@ -4,9 +4,17 @@ require 'json-schema'
 require 'httparty'
 
 require 'cangaroo/logger'
+require 'cangaroo/logger_helper'
 require 'cangaroo/webhook/error'
 require 'cangaroo/webhook/client'
 require 'cangaroo/class_configuration'
 
 module Cangaroo
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Cangaroo::Logger.instance
+    end
+  end
 end

--- a/lib/cangaroo/engine.rb
+++ b/lib/cangaroo/engine.rb
@@ -14,6 +14,7 @@ module Cangaroo
       Rails.configuration.cangaroo.jobs = []
       Rails.configuration.cangaroo.poll_jobs = []
       Rails.configuration.cangaroo.basic_auth = false
+      Rails.configuration.cangaroo.logger = nil
     end
   end
 end

--- a/lib/cangaroo/logger.rb
+++ b/lib/cangaroo/logger.rb
@@ -1,60 +1,18 @@
-require 'logger'
-
 module Cangaroo
-  module Log
-    def log
-      Cangaroo::Log::Writer.instance
+  class Logger
+    include Singleton
+
+    def initialize
+      @logger = Rails.configuration.cangaroo.logger || Rails.logger
     end
 
-    class Writer
-      include Singleton
-
-      attr_reader :default_tags
-
-      def initialize
-        @l = Logger.new(STDOUT)
-        @default_tags = {}
-      end
-
-      def reset_context!
-        @default_tags = {}
-      end
-
-      def context(job)
-        reset_context!
-
-        @default_tags.merge!( job: job.class.to_s,
-                              job_id: job.job_id,
-                              connection: job.class.connection)
-      end
-
-      def error(msg, opts = {})
-        @l.error("#{msg}: #{stringify_tags(opts)}")
-      end
-
-      def info(msg, opts = {})
-        @l.info("#{msg}: #{stringify_tags(opts)}")
-      end
-
-      def debug(msg, opts = {})
-        @l.debug("#{msg}: #{stringify_tags(opts)}")
-      end
-
-      def warn(msg, opts = {})
-        @l.warn("#{msg}: #{stringify_tags(opts)}")
-      end
-
-      private
-
-      def stringify_tags(additional_tags)
-        additional_tags = additional_tags.dup
-
-        if translation = additional_tags.delete(:translation)
-          additional_tags[:translation_id] = translation.id
-          # TODO: extract other important info from the translation
+    %i(debug info warn error).each do |log_method|
+      define_method log_method do |msg, opts = {}|
+        begin
+          @logger.send(log_method, msg, opts)
+        rescue
+          @logger.send(:error, "#{msg}: #{opts}")
         end
-
-        @default_tags.merge(additional_tags).map { |k, v| "#{k}=#{v}" }.join(' ')
       end
     end
   end

--- a/lib/cangaroo/logger.rb
+++ b/lib/cangaroo/logger.rb
@@ -2,16 +2,18 @@ module Cangaroo
   class Logger
     include Singleton
 
+    attr_reader :logger
+
     def initialize
       @logger = Rails.configuration.cangaroo.logger || Rails.logger
     end
 
-    %i(debug info warn error).each do |log_method|
-      define_method log_method do |msg, opts = {}|
+    %i(log unknown debug info warn error).each do |log_method|
+      define_method log_method do |*params|
         begin
-          @logger.send(log_method, msg, opts)
-        rescue
-          @logger.send(:error, "#{msg}: #{opts}")
+          @logger.send(log_method, *params)
+        rescue ArgumentError
+          @logger.send(log_method, params)
         end
       end
     end

--- a/lib/cangaroo/logger_helper.rb
+++ b/lib/cangaroo/logger_helper.rb
@@ -7,7 +7,7 @@ module Cangaroo
     def job_tags(tags = {})
       tags.merge!(job: self.class.to_s,
                   job_id: job_id,
-                  connection: self.class.connection)
+                  connection: self.class.connection.to_s)
     end
   end
 end

--- a/lib/cangaroo/logger_helper.rb
+++ b/lib/cangaroo/logger_helper.rb
@@ -1,0 +1,13 @@
+require 'active_support/concern'
+
+module Cangaroo
+  module LoggerHelper
+    extend ActiveSupport::Concern
+
+    def job_tags(tags = {})
+      tags.merge!(job: self.class.to_s,
+                  job_id: job_id,
+                  connection: self.class.connection)
+    end
+  end
+end

--- a/spec/jobs/cangaroo/job_spec.rb
+++ b/spec/jobs/cangaroo/job_spec.rb
@@ -2,12 +2,6 @@ require 'rails_helper'
 
 module Cangaroo
   RSpec.describe Job, type: :job do
-    class FakeJob < Cangaroo::Job
-      connection :store
-      path '/webhook_path'
-      parameters(email: 'info@nebulab.it')
-    end
-
     let(:job_class) { FakeJob }
     let(:destination_connection) { create(:cangaroo_connection) }
     let(:type) { 'orders' }

--- a/spec/lib/cangaroo/logger_helper_spec.rb
+++ b/spec/lib/cangaroo/logger_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Cangaroo::LoggerHelper do
+  describe '#job_tags' do
+    let(:job_class) { FakeJob }
+    let(:type) { 'orders' }
+    let(:payload) { { id: 'O123' } }
+    let(:options) do
+      { connection: destination_connection,
+        type: type,
+        payload: payload }
+    end
+    let(:job) { job_class.new(options) }
+    let!(:destination_connection) { create(:cangaroo_connection) }
+    let(:extra_tags) { { tag1: 1, tag2: 2 } }
+
+    it 'merges given tags with job class name, job_id and connection name' do
+      expect(job.job_tags(extra_tags)).to eq(extra_tags.merge(job: 'FakeJob', job_id: job.job_id, connection: destination_connection.name))
+    end
+  end
+end

--- a/spec/lib/cangaroo/logger_spec.rb
+++ b/spec/lib/cangaroo/logger_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+class CustomLogger
+  def log(_message); end
+
+  def unknown(_message, _opts = {}); end
+
+  def debug(_message, _opts = {}); end
+
+  def info(_message, _opts = {}); end
+
+  def warn(_message, _opts = {}); end
+
+  def error(_message, _opts = {}); end
+end
+
+describe Cangaroo::Logger do
+  let(:cangaroo_logger) { Cangaroo::Logger.send(:new) }
+  before { Rails.configuration.cangaroo.logger = logger }
+
+  describe '#logger' do
+    subject { cangaroo_logger.logger }
+
+    context 'when Rails.configuration.cangaroo.logger is set' do
+      let(:logger) { CustomLogger.new }
+
+      it { is_expected.to eq(logger) }
+    end
+
+    context 'when Rails.configuration.cangaroo.logger is not set' do
+      let(:logger) { nil }
+
+      it { is_expected.to eq(Rails.logger) }
+    end
+  end
+
+  context 'log methods' do
+    let(:message) { 'message' }
+    let(:opts) { { opt1: 1, opt2: 2 } }
+
+    describe '#log' do
+      after { cangaroo_logger.log(message, opts) }
+
+      context 'when logger can receive given parameters' do
+        let(:logger) { nil }
+
+        it 'calls the logger log method with the given params' do
+          expect(Rails.logger).to receive(:log).with(message, opts)
+        end
+      end
+
+      context 'when logger can not receive given parameters' do
+        let(:logger) { CustomLogger.new }
+
+        it 'calls the logger log method with an array of message and params' do
+          expect(logger).to receive(:log).with([message, opts])
+        end
+      end
+    end
+
+    %i(unknown debug info warn error).each do |log_method|
+      describe "##{log_method}" do
+        after { cangaroo_logger.send(log_method, message, opts) }
+
+        context 'when logger can receive given parameters' do
+          let(:logger) { CustomLogger.new }
+
+          it "calls the logger #{log_method} method with the given params" do
+            expect(logger).to receive(log_method).with(message, opts)
+          end
+        end
+
+        context 'when logger can not receive given parameters' do
+          let(:logger) { nil }
+
+          it "calls the logger #{log_method} method with an array of message and params" do
+            expect(Rails.logger).to receive(log_method).with([message, opts])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ require 'rspec/rails'
   shoulda_matchers
   factory_girl
   spec_helpers
+  fake_job
 ).each { |path| require File.expand_path("../support/#{path}.rb", __FILE__) }
 
 # Checks for pending migrations before tests are run.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
     Rails.configuration.cangaroo.basic_auth = false
     Rails.configuration.cangaroo.jobs = []
     Rails.configuration.cangaroo.poll_job = []
+    Rails.configuration.cangaroo.logger = nil
   end
 
   # The different available types are documented in the features, such as in

--- a/spec/support/fake_job.rb
+++ b/spec/support/fake_job.rb
@@ -1,0 +1,7 @@
+class FakeJob < Cangaroo::Job
+  include Cangaroo::LoggerHelper
+
+  connection :store
+  path '/webhook_path'
+  parameters(email: 'info@nebulab.it')
+end


### PR DESCRIPTION
This PR change the logger class by using `Rails.logger` by default and give the end developers to use a custom log class.
The log class can be customized by setting `Rails.configuration.cangaroo.logger` in a rails initializer or environment file.