### PR TITLE
Update specs for rspec 3

### DIFF
--- a/spec/features/push_flow_spec.rb
+++ b/spec/features/push_flow_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Push flow' do
                                          Cangaroo::WarehouseJob,
                                          Cangaroo::ShippedOrderMailJob]
 
-    post endpoint_index_path, store_payload, headers
+    post endpoint_index_path, params: store_payload, headers: headers
   end
 
   describe 'when new order in state cart coming from store' do

--- a/spec/jobs/cangaroo/poll_job_spec.rb
+++ b/spec/jobs/cangaroo/poll_job_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe Cangaroo::PollJob, type: :job do
       end
 
       it 'updates the poll timestamp' do
-        Cangaroo::Webhook::Client.any_instance.stub(:post).and_return(successful_pull_payload)
+        allow_any_instance_of(Cangaroo::Webhook::Client)
+          .to receive(:post)
+          .and_return(successful_pull_payload)
 
         job.perform
 
@@ -67,15 +69,17 @@ RSpec.describe Cangaroo::PollJob, type: :job do
       end
 
       it 'handles a empty response' do
-        Cangaroo::Webhook::Client.any_instance.stub(:post).and_return('')
+        allow_any_instance_of(Cangaroo::Webhook::Client)
+          .to receive(:post)
+          .and_return('')
 
         job.perform
       end
 
       it 'handles a response with a empty array' do
-        Cangaroo::Webhook::Client.any_instance.stub(:post).and_return(
-          parse_fixture('json_payload_empty.json')
-        )
+        allow_any_instance_of(Cangaroo::Webhook::Client)
+          .to receive(:post)
+          .and_return(parse_fixture('json_payload_empty.json'))
 
         job.perform
       end
@@ -83,7 +87,9 @@ RSpec.describe Cangaroo::PollJob, type: :job do
 
     context 'pull fails' do
       before do
-        Cangaroo::Webhook::Client.any_instance.stub(:post).and_return(parse_fixture('json_payload_ok.json'))
+        allow_any_instance_of(Cangaroo::Webhook::Client)
+          .to receive(:post)
+          .and_return(parse_fixture('json_payload_ok.json'))
 
         allow(Cangaroo::PerformFlow).to receive(:call).and_return(double(success?: false,
                                                                          message: 'bad failure'))

--- a/spec/requests/cangaroo/endpoint_spec.rb
+++ b/spec/requests/cangaroo/endpoint_spec.rb
@@ -13,14 +13,14 @@ module Cangaroo
     context 'when wombat authentication is enabled' do
       describe '#create' do
         before do
-          post endpoint_index_path, request_payload, headers
+          post endpoint_index_path, params: request_payload, headers: headers
         end
 
         it 'accepts only application/json requests' do
           expect(response.status).to eq(202)
 
           headers['Content-Type'] = 'text/html'
-          post endpoint_index_path, {}, headers
+          post endpoint_index_path, params: {}, headers: headers
           expect(response.status).to eq(406)
         end
 
@@ -39,7 +39,7 @@ module Cangaroo
         context 'when error' do
           before do
             headers['X-Hub-Access-Token'] = 'wrongtoken'
-            post endpoint_index_path, request_payload, headers
+            post endpoint_index_path, params: request_payload, headers: headers
           end
 
           it 'responds with the command error code' do
@@ -53,8 +53,8 @@ module Cangaroo
 
         context 'when an exception was raised' do
           before do
-            HandleRequest.stub(:call).and_raise('An error')
-            post endpoint_index_path, request_payload, headers
+            allow(HandleRequest).to receive(:call).and_raise('An error')
+            post endpoint_index_path, params: request_payload, headers: headers
           end
 
           it 'responds with 500' do
@@ -77,7 +77,7 @@ module Cangaroo
         it 'successfully authorized against a connection key and token' do
           headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(connection.key, connection.token)
 
-          post endpoint_index_path, request_payload, headers
+          post endpoint_index_path, params: request_payload, headers: headers
 
           expect(response.status).to eq(202)
         end
@@ -87,13 +87,13 @@ module Cangaroo
 
           headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('', connection.token)
 
-          post endpoint_index_path, request_payload, headers
+          post endpoint_index_path, params: request_payload, headers: headers
 
           expect(response.status).to eq(202)
         end
 
         it 'fails to authenticate when basic auth is not provided' do
-          post endpoint_index_path, request_payload, headers
+          post endpoint_index_path, params: request_payload, headers: headers
 
           expect(response.status).to eq(401)
         end


### PR DESCRIPTION
RSpec 3 introduces some minor syntax changes, so we update the specs to keep pace. This removes deprecation warnings present as of rspec 3.6.0.