### PR TITLE
Optionally set HTTP client timeout

### DIFF
--- a/cangaroo.gemspec
+++ b/cangaroo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
 
   s.add_dependency 'rails', '>= 4.2.4'
-  s.add_dependency 'interactor-rails', '~> 2.0.2'
+  s.add_dependency 'interactor-rails', '~> 2.1.1'
   s.add_dependency 'json-schema', '~> 2.8.0'
   s.add_dependency 'httparty', '~> 0.14.0'
 

--- a/lib/cangaroo/engine.rb
+++ b/lib/cangaroo/engine.rb
@@ -15,6 +15,7 @@ module Cangaroo
       Rails.configuration.cangaroo.poll_jobs = []
       Rails.configuration.cangaroo.basic_auth = false
       Rails.configuration.cangaroo.logger = nil
+      Rails.configuration.cangaroo.client_timeout = nil
     end
   end
 end

--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -27,6 +27,10 @@ module Cangaroo
           }
         end
 
+        if timeout = Rails.configuration.cangaroo.client_timeout
+          request_options[:timeout] = timeout
+        end
+
         req = self.class.post(url, request_options)
 
         sanitized_response = sanitize_response(req)

--- a/spec/lib/cangaroo/webhook/client_spec.rb
+++ b/spec/lib/cangaroo/webhook/client_spec.rb
@@ -49,6 +49,31 @@ module Cangaroo
           end
         end
 
+        describe 'Rails.configuration.cangaroo.client_timeout' do
+
+          context 'when set' do
+            before { Rails.configuration.cangaroo.client_timeout = 120 }
+            it 'sets the timeout config on the client' do
+              expect(client.class).to receive(:post)
+                .with(anything, hash_including(timeout: 120 ))
+                .and_return(double(response: double(code: '200'), parsed_response: response))
+
+              client.post(payload, request_id, parameters)
+            end
+          end
+
+          context 'when not set' do
+            before { Rails.configuration.cangaroo.client_timeout = nil }
+            it 'does not set the timeout config on the client' do
+              allow(client.class).to receive(:post)
+                .with(anything, hash_excluding(:timeout))
+                .and_return(double(response: double(code: '200'), parsed_response: response))
+
+              client.post(payload, request_id, parameters)
+            end
+          end
+        end
+
         context 'when response code is 200 (success)' do
           it 'returns the parsed response' do
             expect(client.post(payload, request_id, parameters))


### PR DESCRIPTION
I've found that this is needed because some endpoints routinely max out the default [Net::HTTP read timeout](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method) (60 seconds) that [HTTParty uses](https://github.com/jnunemaker/httparty/blob/70030731d9a8e2943019adb5747c5060875fc151/lib/httparty/connection_adapter.rb#L96) under the hood.

Usage:

```ruby
# config/initializers/cangaroo.rb
Rails.configuration.cangaroo.client_timeout = 120 # seconds
```

Tests pass for me locally:
<img src="https://user-images.githubusercontent.com/7997618/35156777-dc0c83f8-fcff-11e7-9bf6-6f92f8166062.png" width="50%" />
