### PR TITLE
Namespace PerformFlow in BaseJob#restart_flow to prevent loading issue

### DIFF
--- a/app/jobs/cangaroo/base_job.rb
+++ b/app/jobs/cangaroo/base_job.rb
@@ -19,7 +19,7 @@ module Cangaroo
 
       return unless process_response
 
-      command = PerformFlow.call(
+      command = Cangaroo::PerformFlow.call(
         source_connection: destination_connection,
         json_body: response,
         jobs: Rails.configuration.cangaroo.jobs.reject{ |job| job == self.class }


### PR DESCRIPTION
This prevents:

```
ArgumentError: A copy of Cangaroo::BaseJob has
been removed from the module tree but is still active!
```

This issue prevents PollJobs from:
1. updating poll timestamps
2. processing returned payloads

### To Reproduce

```shell
git clone https://github.com/davidlaprade/cangaroo-loading-issue
cd cangaroo-loading-issue
bundle
bundle exec rake db:create db:migrate db:seed
```

Open 2 separate shells:

```shell
# in the first shell
bundle exec rails s -p 3100 # start the rails server

# in the second shell
bin/delayed_job start # start a worker process
bundle exec rake cangaroo:poll # add a poll job to the queue
tail -f log/delayed_job.log # watch what the worker does
```

Once the `MyPollShipmentJob` runs, you will see the following error in the
worker log file:

```
Job ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper (id=5) (queue=cangaroo)
FAILED (1 prior attempts) with ArgumentError: A copy of Cangaroo::BaseJob has
been removed from the module tree but is still active!
```