### PR TITLE
Include X-HUB-TOKEN header along with X_HUB_TOKEN for better server support

### DIFF
--- a/lib/cangaroo/webhook/client.rb
+++ b/lib/cangaroo/webhook/client.rb
@@ -49,6 +49,7 @@ module Cangaroo
 
       def headers
         {
+          'X-HUB-TOKEN' => connection.token || '',
           'X_HUB_TOKEN' => connection.token || '',
           'Content-Type' => 'application/json',
           'Accept' => 'application/json'

--- a/spec/lib/cangaroo/webhook/client_spec.rb
+++ b/spec/lib/cangaroo/webhook/client_spec.rb
@@ -29,7 +29,7 @@ module Cangaroo
           client.post(payload, request_id, parameters)
           expect(WebMock).to have_requested(:post,
                                             'http://www.store.com/api_path')
-            .with(headers: { 'X_HUB_TOKEN' => connection.token },
+            .with(headers: { 'X-HUB-TOKEN' => connection.token },
                   body: {
                     request_id: request_id,
                     parameters: connection.parameters.deep_merge(parameters),


### PR DESCRIPTION
We currently send along the [X_HUB_TOKEN as a header](
https://github.com/nebulab/cangaroo/blob/c1f5b39c06eab0a19af88d4102bfa0a53527c713/lib/cangaroo/webhook/client.rb#L52) for requests to endpoints:

```
'X_HUB_TOKEN' => connection.token || '',
```

This makes sense, since the [spree/endpoint_base uses X_HUB_TOKEN](https://github.com/spree/endpoint_base/blob/b3077af5b54ba18ed47bdbef01395b0027ad6637/lib/endpoint_base/concerns/token_authorization.rb#L28) for authorization:

```
halt 401 if request.env["HTTP_X_HUB_TOKEN"] != @endpoint_key
```

Unfortunately, use of underscores in HTTP headers is a legacy feature, requiring explicit, non-default configurations on the most common ruby web servers: nginx and apache.

From the [NGinx docs](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/?highlight=disappearing%20http%20headers#missing-disappearing-http-headers):

> If you do not explicitly set underscores_in_headers on;, NGINX will
> silently drop HTTP headers with underscores (which are perfectly valid
> according to the HTTP standard). This is done in order to prevent
> ambiguities when mapping headers to CGI variables as both dashes and
> underscores are mapped to underscores during that process.

And the docs for [recent versions of Apache](https://httpd.apache.org/docs/trunk/new_features_2_4.html):

> Translation of headers to environment variables is more strict than
> before to mitigate some possible cross-site-scripting attacks via header
> injection. Headers containing invalid characters (including underscores)
> are now silently dropped.

Sending along both `HTTP_X_HUB_TOKEN` _and_ `HTTP-X-HUB-TOKEN` should improve compatibility for a majority of users.