### PR TITLE
Fix tests failing on master due to Rails 4 compatibility issues

### DIFF
--- a/spec/features/push_flow_spec.rb
+++ b/spec/features/push_flow_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Push flow' do
                                          Cangaroo::WarehouseJob,
                                          Cangaroo::ShippedOrderMailJob]
 
-    post endpoint_index_path, params: store_payload, headers: headers
+    compatible_http(:post, endpoint_index_path, params: store_payload, headers: headers)
   end
 
   describe 'when new order in state cart coming from store' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ require 'rspec/rails'
   shoulda_matchers
   factory_girl
   spec_helpers
+  compatible_http
 ).each { |path| require File.expand_path("../support/#{path}.rb", __FILE__) }
 
 Dir[File.dirname(__FILE__) + '/support/jobs/*.rb'].each { |file| require file }

--- a/spec/support/compatible_http.rb
+++ b/spec/support/compatible_http.rb
@@ -1,0 +1,8 @@
+# NOTE: this is needed to keep our test suite compatible with both Rails 4 + 5
+# See https://github.com/nebulab/cangaroo/pull/60#issue-175032794
+def compatible_http(method, path, args)
+  case Rails::VERSION::MAJOR
+  when 4 then self.send(method, path, args[:params], args[:headers])
+  when 5 then self.send(method, path, args)
+  end
+end


### PR DESCRIPTION
#51 cleaned up portions of the test suite to remove deprecation warnings generated by Rails5. Unfortunately, it made the test suite incompatible with Rails 4. That's because the `post` method used in the rspec tests is actually a part of Rails. And between Rails `4.2.` and Rails `5.1.` the arity of that method changed. The [`#post` of 4.2. expected multiple positional arguments](https://github.com/rails/rails/blob/7fe69eaef4bf93418733953b8afaef1a757560e3/actionpack/lib/action_controller/test_case.rb#L595), i.e.

```
post path, params, headers
```

whereas the [`#post` of `5.1` expects a hash](https://github.com/rails/rails/blob/b3b193f7d65357970e72711d42db8070dcf92ce4/actionpack/lib/action_controller/test_case.rb#L460), i.e.

```
post path, params: params, headers: headers
```

Using the new, non-positional arguments in the tests fixed the deprecation warnings for Rails 5 at the cost of breaking our Rails 4 tests. Since Rails 5 is still consistent with the old argument pattern (but Rails 4 is not consistent with the new pattern), I suggest that we revert for now. If/when they stop supporting the old arguments in Rails 5 we can decide whether its worth it to maintain backwards compatibility with Rails 4.